### PR TITLE
Installation helper of VMware scripts

### DIFF
--- a/scripts/config/README.md
+++ b/scripts/config/README.md
@@ -1,0 +1,8 @@
+# VMware scripts Installer
+
+## Usage
+
+```bash
+wget https://github.com/NourEddineX/vmware-scripts/raw/main/scripts/config/init-config.sh -O- |  bash
+# Type your user password if it asks 
+``` 

--- a/scripts/config/init-config.sh
+++ b/scripts/config/init-config.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 DEBIAN_FRONTEND=noninteractive
+echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER >/dev/null
 sudo apt update && sudo apt upgrade 
 sudo apt install -y telnet tcpdump open-vm-tools net-tools dialog curl git sed grep
 KERNEL_BOOT_LINE='net.ifnames=0 biosdevname=0'
 grep "$KERNEL_BOOT_LINE" /etc/default/grub >/dev/null || sudo sed -iE "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 $KERNEL_BOOT_LINE\"/g" /etc/default/grub
 sudo update-grub
-echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER >/dev/null
 git clone --single-branch -b main https://github.com/k8-proxy/vmware-scripts.git ~/scripts
 sudo install -T ~/scripts/scripts/wizard/wizard.sh /usr/local/bin/wizard -m 0755
 install -T ~/scripts/scripts/pw-reset-onlogin/pw-reset-onlogin.sh /tmp/pw-reset-onlogin.sh -m 0755

--- a/scripts/config/init-config.sh
+++ b/scripts/config/init-config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DEBIAN_FRONTEND=noninteractive
+sudo apt update && sudo apt upgrade 
+sudo apt install -y telnet tcpdump open-vm-tools net-tools dialog curl git sed grep
+KERNEL_BOOT_LINE='net.ifnames=0 biosdevname=0'
+grep "$KERNEL_BOOT_LINE" /etc/default/grub >/dev/null || sudo sed -iE "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 $KERNEL_BOOT_LINE\"/g" /etc/default/grub
+sudo update-grub
+echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER >/dev/null
+git clone --single-branch -b main https://github.com/k8-proxy/vmware-scripts.git ~/scripts
+sudo install -T ~/scripts/scripts/wizard/wizard.sh /usr/local/bin/wizard -m 0755
+install -T ~/scripts/scripts/pw-reset-onlogin/pw-reset-onlogin.sh /tmp/pw-reset-onlogin.sh -m 0755


### PR DESCRIPTION
- setup predictable network interfaces naming
- install some needed commands
- download vmware scripts repo to ~/scripts
- user will be able to run sudo without being asked for password
