### PR TITLE
Typo fix, node exporter installation fix

### DIFF
--- a/packer/esxi.json
+++ b/packer/esxi.json
@@ -18,7 +18,7 @@
             "ssh_host":"{{ user `ssh_host` }}",
             "ssh_username": "{{user `ssh_user`}}",
             "ssh_password": "Gl@$$wall",
-            "ssh_timeout": "10m",
+            "ssh_timeout": "15m",
             "pause_before_connecting": "10s",
             "vnc_over_websocket": true,
             "insecure_connection": true,

--- a/scripts/config/init-config.sh
+++ b/scripts/config/init-config.sh
@@ -39,11 +39,11 @@ sudo ln -s /usr/local/bin/node_exporter /usr/sbin/node_exporter
 sudo useradd node_exporter -s /sbin/nologin
 
 # create node exporter service
-sudo cp ~/scripts/visuallog/monitoring-scripts/node_exporter.service /etc/systemd/system/node_exporter.service
+sudo cp ~/scripts/visualog/monitoring-scripts/node_exporter.service /etc/systemd/system/node_exporter.service
 sudo mkdir -p /etc/prometheus
 
 # install node exporter configuration
-sudo cp ~/scripts/visuallog/monitoring-scripts/node_exporter.config /etc/prometheus/node_exporter.config
+sudo cp ~/scripts/visualog/monitoring-scripts/node_exporter.config /etc/prometheus/node_exporter.config
 sudo systemctl daemon-reload
 
 # start and enable node_exporter service


### PR DESCRIPTION
- Fix typo caused issues with vm metrics installation
- increase timeout, (some times reached)