### PR TITLE
K8-rebuild filedrop: Fix submodules for license file not getting updated

### DIFF
--- a/packer/target/filedrop/setup.sh
+++ b/packer/target/filedrop/setup.sh
@@ -14,7 +14,7 @@ curl -sfL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 
 echo "Done installing helm"
 
 # get source code
-git clone https://github.com/k8-proxy/k8-rebuild.git --recursive && cd k8-rebuild && git submodule foreach git pull origin main
+git clone https://github.com/k8-proxy/k8-rebuild.git --recursive && cd k8-rebuild && git submodule update --init --recursive && git submodule foreach git pull origin main && pushd k8-rebuild-rest-api && git pull origin main && pushd libs/ && git pull origin master && popd && popd
 
 # build docker images
 sudo apt-get install \


### PR DESCRIPTION
Fix issue with setup script for K8 rebuild packer template not pulling last updates from filetrust/sdk-rebuild-eval and few other repos